### PR TITLE
Convert to Sopel 7 (actually 6+) URL handling

### DIFF
--- a/torrentinfo.py
+++ b/torrentinfo.py
@@ -16,8 +16,8 @@ NYAA_URL = 'https://nyaa.si/view/%s'
 ANIDEX_URL = 'https://anidex.info/torrent/%s'
 
 
-@module.rule('.*https?:\/\/(?:www\.)?nyaa\.si\/(?:view|download)\/(\d+).*')
-def nyaa_info(bot, trigger):
+@module.url(r'https?:\/\/(?:www\.)?nyaa\.si\/(?:view|download)\/(\d+)')
+def nyaa_info(bot, trigger, match=None):
     parsed_url = NYAA_URL % trigger.group(1)
     try:
         r = requests.get(url=parsed_url, timeout=(10.0, 4.0))
@@ -46,8 +46,8 @@ def nyaa_info(bot, trigger):
     bot.say("[Nyaa] Name: {name} | {category} | Size: {size} | {uploader}".format(**t))
 
 
-@module.rule('.*https?:\/\/(?:www\.)?anidex\.(?:info|moe)\/(?:torrent|dl)\/(\d+).*')
-def anidex_info(bot, trigger):
+@module.url(r'https?:\/\/(?:www\.)?anidex\.(?:info|moe)\/(?:torrent|dl)\/(\d+)')
+def anidex_info(bot, trigger, match=None):
     parsed_url = ANIDEX_URL % trigger.group(1)
     try:
         r = requests.get(url=parsed_url, timeout=(10.0, 4.0))


### PR DESCRIPTION
Since Sopel 7.0, the `url` decorator always works even if `url.py` isn't enabled. It's finally safe to use that instead of `rule`.

Also converted strings with invalid escape sequences (regex patterns) to raw so Python won't complain about deprecations.