### PR TITLE
Restructure as package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,57 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/

--- a/COPYING
+++ b/COPYING
@@ -1,0 +1,23 @@
+
+  Eiffel Forum License, version 2
+
+   1. Permission is hereby granted to use, copy, modify and/or
+      distribute this package, provided that:
+          * copyright notices are retained unchanged,
+          * any distribution of this package, whether modified or not,
+      includes this license text.
+   2. Permission is hereby also granted to distribute binary programs
+      which depend on this package. If the binary program depends on a
+      modified version of this package, you are encouraged to publicly
+      release the modified version of this package.
+
+***********************
+
+THIS PACKAGE IS PROVIDED "AS IS" AND WITHOUT WARRANTY. ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE AUTHORS BE LIABLE TO ANY PARTY FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES ARISING IN ANY WAY OUT OF THE USE OF THIS PACKAGE.
+
+***********************

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include NEWS
+include COPYING
+include README.md
+
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]

--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # sopel-torrentinfo
-Sopel module that fetches info about torrent links
+
+Sopel plugin to fetch info for torrent links.
 
 ## Current status
 
-The current support is very limited, just a proof of doing something. It fetches
-only from Nyaa.si and Anidex.info, and then only a very few details. More
-information (and possibly other supported sites) will come later.
+The current support is very limited, just a proof of doing something. It
+fetches only from Nyaa.si and Anidex.info, and then only a very few details.
+More information (and possibly other supported sites) will come later.
 
 ## Requirements
-The torrentinfo module relies on the following Python components:
+
+The `torrentinfo` plugin relies on Sopel 7.1+ and the following PyPI packages:
 
 * `bleach`
 * `cssselect`
@@ -18,5 +20,6 @@ The torrentinfo module relies on the following Python components:
 Only tested on Python 3, due to Python 2 reaching EOL on January 1, 2020.
 
 ## Usage
-There are no commands. Just enable the module and it will fetch info about
-supported torrents automatically.
+
+There are no commands. Just enable the plugin and it will fetch info about
+supported torrents automatically when links appear in chat.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,29 @@
+[metadata]
+name = sopel-torrentinfo
+version = 0.1.0
+description = Sopel plugin to fetch info for torrent links.
+author = dgw
+author_email = dgw@technobabbl.es
+url = https://github.com/dgw/sopel-torrentinfo
+license = Eiffel Forum License, version 2
+classifiers =
+    Intended Audience :: Developers
+    Intended Audience :: System Administrators
+    License :: Eiffel Forum License (EFL)
+    License :: OSI Approved :: Eiffel Forum License
+    Topic :: Communications :: Chat :: Internet Relay Chat
+
+[options]
+packages = find:
+zip_safe = false
+include_package_data = true
+install_requires =
+    sopel>=7.1
+    bleach
+    cssselect
+    lxml
+    # also requests, but Sopel itself requires that
+
+[options.entry_points]
+sopel.plugins =
+    torrentinfo = sopel_torrentinfo

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+import os
+import sys
+from setuptools import setup, find_packages
+
+
+if __name__ == '__main__':
+    print('Sopel does not correctly load plugins installed with setup.py '
+          'directly. Please use "pip install .", or add '
+          '{}/sopel_torrentinfo to core.extra in your config.'
+          .format(os.path.dirname(os.path.abspath(__file__))),
+          file=sys.stderr)
+
+with open('README.md') as readme_file:
+    readme = readme_file.read()
+
+with open('NEWS') as history_file:
+    history = history_file.read()
+
+
+setup(
+    long_description=readme + '\n\n' + history,
+    long_description_content_type='text/markdown',
+)

--- a/sopel_torrentinfo/__init__.py
+++ b/sopel_torrentinfo/__init__.py
@@ -1,22 +1,23 @@
 # coding=utf-8
 """
-torrentinfo.py - Sopel module to fetch torrent information for links sent to channels
+torrentinfo - Sopel plugin to fetch info for torrent links
 """
 
 import re
 
 import bleach
-import requests
 from lxml import etree
+import requests
 
-from sopel import module, web
+from sopel import plugin
+from sopel.tools import web
 
 
 NYAA_URL = 'https://nyaa.si/view/%s'
 ANIDEX_URL = 'https://anidex.info/torrent/%s'
 
 
-@module.url(r'https?:\/\/(?:www\.)?nyaa\.si\/(?:view|download)\/(\d+)')
+@plugin.url(r'https?:\/\/(?:www\.)?nyaa\.si\/(?:view|download)\/(\d+)')
 def nyaa_info(bot, trigger, match=None):
     parsed_url = NYAA_URL % match.group(1)
     try:
@@ -46,7 +47,7 @@ def nyaa_info(bot, trigger, match=None):
     bot.say("[Nyaa] Name: {name} | {category} | Size: {size} | {uploader}".format(**t))
 
 
-@module.url(r'https?:\/\/(?:www\.)?anidex\.(?:info|moe)\/(?:torrent|dl)\/(\d+)')
+@plugin.url(r'https?:\/\/(?:www\.)?anidex\.(?:info|moe)\/(?:torrent|dl)\/(\d+)')
 def anidex_info(bot, trigger, match=None):
     parsed_url = ANIDEX_URL % match.group(1)
     try:


### PR DESCRIPTION
1. This means the plugin can be published on PyPI someday
2. Switching from single-file to package structure is a prerequisite for a later rewrite that will allow support for other torrent sites to be installed as add-ons ("providers" or something like that)

Switched from `sopel.module` to `sopel.plugin` in anticipation of the former's removal in a future Sopel release.