### PR TITLE
Remove non-working AniDex support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,13 @@ Sopel plugin to fetch info for torrent links.
 ## Current status
 
 The current support is very limited, just a proof of doing something. It
-fetches only from Nyaa.si and Anidex.info, and then only a very few details.
-More information (and possibly other supported sites) will come later.
+fetches only from Nyaa.si, and then only a very few details. More information
+(and possibly other supported sites) will come later.
 
 ## Requirements
 
 The `torrentinfo` plugin relies on Sopel 7.1+ and the following PyPI packages:
 
-* `bleach`
 * `cssselect`
 * `etree` from `lxml`
 * `requests`

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ zip_safe = false
 include_package_data = true
 install_requires =
     sopel>=7.1
-    bleach
     cssselect
     lxml
     # also requests, but Sopel itself requires that

--- a/sopel_torrentinfo/__init__.py
+++ b/sopel_torrentinfo/__init__.py
@@ -3,18 +3,13 @@
 torrentinfo - Sopel plugin to fetch info for torrent links
 """
 
-import re
-
-import bleach
 from lxml import etree
 import requests
 
 from sopel import plugin
-from sopel.tools import web
 
 
 NYAA_URL = 'https://nyaa.si/view/%s'
-ANIDEX_URL = 'https://anidex.info/torrent/%s'
 
 
 @plugin.url(r'https?:\/\/(?:www\.)?nyaa\.si\/(?:view|download)\/(\d+)')
@@ -45,37 +40,3 @@ def nyaa_info(bot, trigger, match=None):
     for key in t.keys():
         t[key] = (' '.join(t[key].split()))
     bot.say("[Nyaa] Name: {name} | {category} | Size: {size} | {uploader}".format(**t))
-
-
-@plugin.url(r'https?:\/\/(?:www\.)?anidex\.(?:info|moe)\/(?:torrent|dl)\/(\d+)')
-def anidex_info(bot, trigger, match=None):
-    parsed_url = ANIDEX_URL % match.group(1)
-    try:
-        r = requests.get(url=parsed_url, timeout=(10.0, 4.0))
-    except requests.exceptions.ConnectTimeout:
-        return bot.say("[Anidex] Connection timed out.")
-    except requests.exceptions.ConnectionError:
-        return bot.say("[Anidex] Couldn't connect to server.")
-    except requests.exceptions.ReadTimeout:
-        return bot.say("[Anidex] Server took too long to send data.")
-    try:
-        r.raise_for_status()
-    except requests.exceptions.HTTPError as e:
-        return bot.say("[Anidex] HTTP error: " + str(e))
-
-    page = etree.HTML(r.content)
-
-    t = {}
-
-    t['name'] = page.cssselect('#content > div.panel.panel-default > div > h3')[0]
-    t['size'] = page.cssselect('#scrape_info_table > tbody > tr:nth-child(2) > td')[0]
-    t['uploader'] = page.cssselect('#edit_torrent_form > div.row > div:nth-child(1) > table:nth-child(1) > tbody > tr:nth-child(1) > td > a')[0]
-    for key in t.keys():
-        t[key] = web.decode(' '.join((bleach.clean(etree.tostring(
-            t[key],
-            encoding='utf-8').decode('utf-8'),
-            tags=[], strip=True)).split())).strip()
-    t['link'] = parsed_url
-    t['name'] = re.sub(r'\ \+(\d)+', '', t['name'])
-
-    bot.say("[Anidex] Name: {name} | Size: {size} | Uploaded by: {uploader}".format(**t))


### PR DESCRIPTION
AniDex still doesn't have an API, and their DDoS protection blocks bots like Sopel from scraping the site HTML (returns only 403 Forbidden). I couldn't find any way around the protection filter.