### PR TITLE
Refactor to provider-based plugin (extensibility)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,3 +26,5 @@ install_requires =
 [options.entry_points]
 sopel.plugins =
     torrentinfo = sopel_torrentinfo
+sopel_torrentinfo.providers =
+    nyaa = sopel_torrentinfo.providers:Nyaa

--- a/sopel_torrentinfo/__init__.py
+++ b/sopel_torrentinfo/__init__.py
@@ -19,8 +19,9 @@ def setup(bot):
     patterns = []
 
     for entry_point in entry_points:
-        provider = bot.memory['torrentinfo_providers'][entry_point.name] = entry_point.load()
-        patterns.append(provider.link_pattern())
+        provider = entry_point.load()
+        bot.memory['torrentinfo_providers'][entry_point.name] = provider = provider()
+        patterns.append(provider.get_url_pattern())
 
 
 def lazy_handlers(settings):
@@ -30,10 +31,10 @@ def lazy_handlers(settings):
 @plugin.url_lazy(lazy_handlers)
 def torrent_info(bot, trigger):
     for name, provider in bot.memory['torrentinfo_providers'].items():
-        if provider.link_pattern().match(trigger.group(0)):
+        if provider.get_url_pattern().match(trigger.group(0)):
             break
 
-    display_name = provider.display_name()
+    display_name = provider.DISPLAY_NAME
     fetch_url = provider.get_fetch_url(trigger)
 
     try:

--- a/sopel_torrentinfo/providers.py
+++ b/sopel_torrentinfo/providers.py
@@ -11,27 +11,29 @@ from lxml import etree
 class TorrentInfoProvider(abc.ABC):
     """Base class for torrent link info providers."""
 
-    @staticmethod
+    @property
     @abc.abstractmethod
-    def link_pattern():
-        """Must return a compiled regex pattern matching links this provider can handle."""
+    def URL_PATTERN(self):
+        """Required URL pattern, as it would be passed to ``@plugin.url`` decorator."""
 
-    @classmethod
-    def display_name(cls):
+    def get_url_pattern(self):
+        """Compile and return the URL pattern for Sopel's rule manager."""
+        return re.compile(self.URL_PATTERN)
+
+    @property
+    def DISPLAY_NAME(self):
         """Define a human-readable name for this provider.
 
         For example, ``Nyaa`` or ``TokyoTosho``.
 
         If not overridden, will return the class's ``__name__``.
         """
-        return cls.__name__
+        return self.__class__.__name__
 
-    @staticmethod
     @abc.abstractmethod
-    def get_fetch_url(trigger):
+    def get_fetch_url(self, trigger):
         """Return the URL to fetch, given a matching URL ``trigger``."""
 
-    @staticmethod
     @abc.abstractmethod
     def parse(response):
         """Parse the fetched ``response`` data.
@@ -56,16 +58,12 @@ class TorrentInfoProvider(abc.ABC):
 class Nyaa(TorrentInfoProvider):
     """Handler for Nyaa.si links."""
 
-    @staticmethod
-    def link_pattern():
-        return re.compile(r'https?:\/\/(?:www\.)?nyaa\.si\/(?:view|download)\/(\d+)')
+    URL_PATTERN = r'https?:\/\/(?:www\.)?nyaa\.si\/(?:view|download)\/(\d+)'
 
-    @staticmethod
-    def get_fetch_url(trigger):
+    def get_fetch_url(self, trigger):
         return 'https://nyaa.si/view/%s' % trigger.group(1)
 
-    @staticmethod
-    def parse(response):
+    def parse(self, response):
         page = etree.HTML(response.content)
 
         t = []

--- a/sopel_torrentinfo/providers.py
+++ b/sopel_torrentinfo/providers.py
@@ -1,0 +1,79 @@
+# coding=utf-8
+"""Link handling provider logic."""
+
+
+import abc
+import re
+
+from lxml import etree
+
+
+class TorrentInfoProvider(abc.ABC):
+    """Base class for torrent link info providers."""
+
+    @staticmethod
+    @abc.abstractmethod
+    def link_pattern():
+        """Must return a compiled regex pattern matching links this provider can handle."""
+
+    @classmethod
+    def display_name(cls):
+        """Define a human-readable name for this provider.
+
+        For example, ``Nyaa`` or ``TokyoTosho``.
+
+        If not overridden, will return the class's ``__name__``.
+        """
+        return cls.__name__
+
+    @staticmethod
+    @abc.abstractmethod
+    def get_fetch_url(trigger):
+        """Return the URL to fetch, given a matching URL ``trigger``."""
+
+    @staticmethod
+    @abc.abstractmethod
+    def parse(response):
+        """Parse the fetched ``response`` data.
+
+        The ``response`` is a ``requests.Response`` object, just as if the
+        provider called ``requests.get()`` itself.
+
+        This method is expected to return an iterable of pieces, for example::
+
+            [
+                'Title: 60th Annual Kohaku',
+                'Uploader: NHK Official',
+                'Size: 420.69 GiB',
+                ...,
+            ]
+
+        These pieces will be joined together by the plugin's output stage, in
+        combination with a prefix based on the provider's ``display_name()``.
+        """
+
+
+class Nyaa(TorrentInfoProvider):
+    """Handler for Nyaa.si links."""
+
+    @staticmethod
+    def link_pattern():
+        return re.compile(r'https?:\/\/(?:www\.)?nyaa\.si\/(?:view|download)\/(\d+)')
+
+    @staticmethod
+    def get_fetch_url(trigger):
+        return 'https://nyaa.si/view/%s' % trigger.group(1)
+
+    @staticmethod
+    def parse(response):
+        page = etree.HTML(response.content)
+
+        t = []
+
+        t.append(page.cssselect('meta[property="og:title"]')[0].get('content').replace(' :: Nyaa', ''))
+        t.append(page.cssselect('meta[property="og:description"]')[0].get('content').split("|", 1)[0])
+        t.append(page.cssselect('meta[property="og:description"]')[0].get('content').split("|", 2)[1])
+        t.append(page.cssselect('meta[property="og:description"]')[0].get('content').split("|", 3)[2])
+        t.append(response.url)
+
+        return t


### PR DESCRIPTION
Existing Nyaa functionality is now the only built-in provider, serving as an example for supporting other sites.

Anyone can now publish a package with (a) `sopel_torrentinfo.providers` entry point(s) that handles links for any arbitrary site.

Of course there is no actual limitation to torrent indexes. Honestly, this approach looks great for a generic, pluggable link-info fetcher usable with any site. This plugin handles fetch errors for free, and the provider/entry-point deals with parsing the data if fetching is successful.

### To Do

~~One remaining potential enhancement for maintainability (no effect on function) would be creating a Manager object to keep track of the available providers. Such is @Exirel's suggestion, instead of just dumping them in a list.~~ Done.