### PR TITLE
Add URL for non-view Nyaa links & modify provider interface to support

### DIFF
--- a/sopel_torrentinfo/__init__.py
+++ b/sopel_torrentinfo/__init__.py
@@ -50,4 +50,12 @@ def torrent_info(bot, trigger):
     except requests.exceptions.HTTPError as e:
         return bot.say("[{}] HTTP error: ".format(display_name) + str(e))
 
-    bot.say("[{}] ".format(display_name) + ' | '.join([s.strip() for s in provider.parse(r)]))
+    bot.say(
+        "[{}] ".format(display_name) + (
+            ' | '.join([
+                s.strip()
+                for s
+                in provider.parse(r, trigger)
+            ])
+        )
+    )


### PR DESCRIPTION
Requires passing the `trigger` to `TorrentInfoProvider.parse()` calls, since it must inspect the match groups to decide whether a link should be part of the output or not.

Reformatted the messy `bot.say()` in the main plugin file, since I had to touch it (and make it even longer) anyway.